### PR TITLE
Improve firewall service name check for < win2k8

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,7 +21,7 @@ class windows_firewall (
     validate_re($ensure,['^(running|stopped)$'])
 
     case $::operatingsystemversion {
-        'Windows Server 2003','Windows Server 2003 R2','Windows XP': {
+        /Windows Server 2003/,/Windows Server 2003 R2/,/Windows XP/: {
           $firewall_name = 'SharedAccess'
         }
         default: {


### PR DESCRIPTION
On some versions of Windows, "operatingsystemversion" may return extra
information in the version string (such as preprending "Microsoft").
This commit fixes the module so that it will find the correct service
name on these versions.
