### PR TITLE
windows_firewall::exception ensure=>absent does not remove port rules on Windows 2012R2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.0.2
+Added support for matching remote ports
+
+1.0.1
+Fixed rules not being deleted
 
 0.0.3
 Add program rule support, various other fixes

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Once the windows firewall is managed you may then want to start managing the rul
       enabled      => 'yes',
       protocol     => 'TCP',
       local_port   => '5985',
+      remote_port  => 'any',
       display_name => 'Windows Remote Management HTTP-In',
       description  => 'Inbound rule for Windows Remote Management via WS-Management. [TCP 5985]',
     }
@@ -85,7 +86,10 @@ Determines whether the exception is enabled, either: 'yes' or 'no'. Defaults to 
 Sets the protocol to be included in the exception rule, either: 'TCP' or 'UDP'.
 
 #####`local_port`
-Defines the port to be included in the exception for port-based exception rules.
+Defines the local port to be included in the exception for port-based exception rules.
+
+#####`remote_port`
+Defines the remote port to be included in the exception for port-based exception rules.
 
 #####`remote_ip`
 Specifies remote hosts that can use this rule.

--- a/manifests/exception.pp
+++ b/manifests/exception.pp
@@ -153,7 +153,11 @@ define windows_firewall::exception(
         $netsh_command = "C:\\Windows\\System32\\netsh.exe firewall ${fw_action} ${fw_command} name=\"${display_name}\" mode=${mode} ${allow_context}"
       }
       default: {
-        $netsh_command = "C:\\Windows\\System32\\netsh.exe advfirewall firewall ${fw_action} rule name=\"${display_name}\" ${fw_description} dir=${direction} action=${action} enable=${enabled} edge=${allow_edge_traversal} ${allow_context} remoteip=\"${remote_ip}\""
+        if $fw_action == 'delete' and $program == undef {
+          $netsh_command = "C:\\Windows\\System32\\netsh.exe advfirewall firewall ${fw_action} rule name=\"${display_name}\" ${fw_description} dir=${direction} ${allow_context} remoteip=\"${remote_ip}\""
+        } else {
+          $netsh_command = "C:\\Windows\\System32\\netsh.exe advfirewall firewall ${fw_action} rule name=\"${display_name}\" ${fw_description} dir=${direction} action=${action} enable=${enabled} edge=${allow_edge_traversal} ${allow_context} remoteip=\"${remote_ip}\""
+        }
       }
     }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":         "puppet-windows_firewall",
-  "version":      "1.0.1",
+  "version":      "1.0.2",
   "author":       "puppetcommunity",
   "license":      "MIT",
   "summary":      "Module that will manage the windows firewall and it's exceptions",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":         "puppet-windows_firewall",
-  "version":      "1.0.0",
+  "version":      "1.0.1",
   "author":       "puppetcommunity",
   "license":      "MIT",
   "summary":      "Module that will manage the windows firewall and it's exceptions",

--- a/spec/defines/windows_firewall/exception_spec.rb
+++ b/spec/defines/windows_firewall/exception_spec.rb
@@ -116,7 +116,7 @@ describe 'windows_firewall::exception', :type => :define do
       end
 
       it { should contain_exec('set rule Windows Remote Management').with(
-        'command' => 'C:\\Windows\\System32\\netsh.exe advfirewall firewall delete rule name="Windows Remote Management"  dir=in action=allow enable=yes edge=no protocol=TCP localport=5985 remoteip=""',
+        'command' => 'C:\\Windows\\System32\\netsh.exe advfirewall firewall delete rule name="Windows Remote Management"  dir=in protocol=TCP localport=5985 remoteip=""',
         'provider' => 'windows'
       ) }
     end

--- a/spec/defines/windows_firewall/exception_spec.rb
+++ b/spec/defines/windows_firewall/exception_spec.rb
@@ -30,13 +30,13 @@ describe 'windows_firewall::exception', :type => :define do
      let :title do 'Windows Remote Management' end
      let :params do
        { :ensure => 'present', :direction => 'in', :action => 'allow', :enabled => 'yes',
-         :protocol => 'TCP', :local_port => '5985',
+         :protocol => 'TCP', :local_port => '5985', :remote_port => 'any',
          :display_name => 'Windows Remote Management', :description => 'Inbound rule for WinRM'
        }
      end
 
      it { should contain_exec('set rule Windows Remote Management').with(
-       'command' => 'C:\\Windows\\System32\\netsh.exe advfirewall firewall add rule name="Windows Remote Management" description="Inbound rule for WinRM" dir=in action=allow enable=yes edge=no protocol=TCP localport=5985 remoteip=""',
+       'command' => 'C:\\Windows\\System32\\netsh.exe advfirewall firewall add rule name="Windows Remote Management" description="Inbound rule for WinRM" dir=in action=allow enable=yes edge=no protocol=TCP localport=5985 remoteport=any remoteip=""',
        'provider' => 'windows'
      ) }
     end
@@ -110,13 +110,13 @@ describe 'windows_firewall::exception', :type => :define do
       let :title do 'Windows Remote Management' end
       let :params do
         { :ensure => 'absent', :direction => 'in', :action => 'allow', :enabled => 'yes',
-          :protocol => 'TCP', :local_port => '5985',
+          :protocol => 'TCP', :local_port => '5985', :remote_port => 'any',
           :display_name => 'Windows Remote Management', :description => 'Inbound rule for WinRM'
         }
       end
 
       it { should contain_exec('set rule Windows Remote Management').with(
-        'command' => 'C:\\Windows\\System32\\netsh.exe advfirewall firewall delete rule name="Windows Remote Management"  dir=in protocol=TCP localport=5985 remoteip=""',
+        'command' => 'C:\\Windows\\System32\\netsh.exe advfirewall firewall delete rule name="Windows Remote Management"  dir=in protocol=TCP localport=5985 remoteport=any remoteip=""',
         'provider' => 'windows'
       ) }
     end


### PR DESCRIPTION
I hit this bug on Windows 2012R2 and 1.0.0 of this module using port rules.  I cannot comment on other combinations of versions and usage.

In the scenario described above, the parameters passed to `netsh advfirewall delete rule` should not contain 'action', 'enable' or 'edge' otherwise errors are produced and the rule is NOT deleted.

In this fork I have addressed this issue and updated the spec tests.  Can we please get this pulled across into the core module?