### PR TITLE
adding powershell and win_facts dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,9 +14,8 @@
     }
   ],
   "dependencies": [
-    {
-      "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 3.0.0 <5.0.0"
-    }
+    { "name": "puppetlabs/stdlib", "version_requirement": ">= 3.0.0 <5.0.0" },
+    { "name": "puppetlabs/registry", "version_requirement": ">= 0.1.1" },
+    { "name": "liamjbennett/win_facts", "version_requirement": ">= 0.0.1" }
   ]
 }


### PR DESCRIPTION
Hi puppet-community devs,

The dependencies listed at https://forge.puppetlabs.com/puppet/windows_firewall/dependencies does not seem to properly show this modules dependencies. I updated the metadata.json to add what seems to be the required modules.  I tested the changes with metadata-json-lint and  set the lowest version currently supported from both modules forge page.  This somewhat addresses issue #5 especially for librarian and r10k users.

With win_facts missing will result in wrong conditional handling with $::operatingsystemversion

With puppetlabs/registry missing in the environment results in the error:

    Error 400 on SERVER: Puppet::Parser::AST::Resource failed with error ArgumentError: Invalid resource type registry_value

- Thank you
