### PR TITLE
bump to 1.0.3 + reformat changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,27 @@
-1.0.2
-Added support for matching remote ports
+## 2016-05-08 Release 1.0.3
 
-1.0.1
-Fixed rules not being deleted
+* modulesync with voxpupuli defaults
 
-0.0.3
-Add program rule support, various other fixes
+## 2016-02-03 Release 1.0.2
 
-0.0.2
-Some bug fixes and additional testing
+* Added support for matching remote ports
 
-0.0.1
-The initial version
+
+## 2015-07-23 Release 1.0.1
+
+* Fixed rules not being deleted
+
+
+## 2013-10-20 Release 0.0.3
+
+* Add program rule support, various other fixes
+
+
+## 2013-10-20 Release 0.0.2
+
+* Some bug fixes and additional testing
+
+
+## 2013-10-20 Release 0.0.1
+
+* The initial version

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":         "puppet-windows_firewall",
-  "version":      "1.0.2",
+  "version":      "1.0.3",
   "author":       "puppet",
   "license":      "MIT",
   "summary":      "Module that will manage the windows firewall and it's exceptions",


### PR DESCRIPTION
we didn't publish 1.0.1 and 1.0.2, the last release was a long long time ago. we should publish the last changes.