### PR TITLE
Remove hardcoded c drive reference for firewall exceptions

### DIFF
--- a/manifests/exception.pp
+++ b/manifests/exception.pp
@@ -148,7 +148,8 @@ define windows_firewall::exception(
     }
 
     # Set command to check for existing rules
-    $check_rule_existance= "C:\\Windows\\System32\\netsh.exe advfirewall firewall show rule name=\"${display_name}\""
+    $netsh_exe = "${facts['os']['windows']['system32']}\\netsh.exe"
+    $check_rule_existance= "${netsh_exe} advfirewall firewall show rule name=\"${display_name}\""
 
     # Use unless for exec if we want the rule to exist, include a description
     if $ensure == 'present' {
@@ -170,13 +171,13 @@ define windows_firewall::exception(
           'yes' => 'ENABLE',
           'no'  => 'DISABLE',
         }
-        $netsh_command = "C:\\Windows\\System32\\netsh.exe firewall ${fw_action} ${fw_command} name=\"${display_name}\" mode=${mode} ${allow_context}"
+        $netsh_command = "${netsh_exe} firewall ${fw_action} ${fw_command} name=\"${display_name}\" mode=${mode} ${allow_context}"
       }
       default: {
         if $fw_action == 'delete' and $program == undef {
-          $netsh_command = "C:\\Windows\\System32\\netsh.exe advfirewall firewall ${fw_action} rule name=\"${display_name}\" ${fw_description} dir=${direction} ${allow_context} remoteip=\"${remote_ip}\""
+          $netsh_command = "${netsh_exe} advfirewall firewall ${fw_action} rule name=\"${display_name}\" ${fw_description} dir=${direction} ${allow_context} remoteip=\"${remote_ip}\""
         } else {
-          $netsh_command = "C:\\Windows\\System32\\netsh.exe advfirewall firewall ${fw_action} rule name=\"${display_name}\" ${fw_description} dir=${direction} action=${action} enable=${enabled} edge=${allow_edge_traversal} ${allow_context} remoteip=\"${remote_ip}\""
+          $netsh_command = "${netsh_exe} advfirewall firewall ${fw_action} rule name=\"${display_name}\" ${fw_description} dir=${direction} action=${action} enable=${enabled} edge=${allow_edge_traversal} ${allow_context} remoteip=\"${remote_ip}\""
         }
       }
     }

--- a/spec/defines/windows_firewall/exception_spec.rb
+++ b/spec/defines/windows_firewall/exception_spec.rb
@@ -4,7 +4,14 @@ describe 'windows_firewall::exception', type: :define do
   ['Windows Server 2003', 'Windows Server 2003 R2', 'Windows XP'].each do |os|
     context "port rule with OS: #{os}, ensure: present" do
       let :facts do
-        { operatingsystemversion: os }
+        {
+          operatingsystemversion: os,
+          os: {
+            windows: {
+              system32: 'C:\\windows\\system32'
+            }
+          }
+        }
       end
       let(:title) { 'Windows Remote Management' }
       let :params do
@@ -17,7 +24,7 @@ describe 'windows_firewall::exception', type: :define do
 
       it do
         is_expected.to contain_exec('set rule Windows Remote Management').with(
-          'command' => 'C:\\Windows\\System32\\netsh.exe firewall add portopening name="Windows Remote Management" mode=ENABLE protocol=TCP port=5985',
+          'command' => 'C:\\windows\\system32\\netsh.exe firewall add portopening name="Windows Remote Management" mode=ENABLE protocol=TCP port=5985',
           'provider' => 'windows'
         )
       end
@@ -27,7 +34,14 @@ describe 'windows_firewall::exception', type: :define do
   ['Windows Server 2012', 'Windows Server 2008', 'Windows Server 2008 R2', 'Windows 8', 'Windows 7', 'Windows Vista'].each do |os|
     context "port rule with OS: #{os}, ensure: present" do
       let :facts do
-        { operatingsystemversion: os }
+        {
+          operatingsystemversion: os,
+          os: {
+            windows: {
+              system32: 'C:\\windows\\system32'
+            }
+          }
+        }
       end
       let(:title) { 'Windows Remote Management' }
       let :params do
@@ -40,7 +54,7 @@ describe 'windows_firewall::exception', type: :define do
 
       it do
         is_expected.to contain_exec('set rule Windows Remote Management').with(
-          'command' => 'C:\\Windows\\System32\\netsh.exe advfirewall firewall add rule name="Windows Remote Management" description="Inbound rule for WinRM" dir=in action=allow enable=yes edge=no protocol=TCP localport=5985 remoteport=any remoteip=""',
+          'command' => 'C:\\windows\\system32\\netsh.exe advfirewall firewall add rule name="Windows Remote Management" description="Inbound rule for WinRM" dir=in action=allow enable=yes edge=no protocol=TCP localport=5985 remoteport=any remoteip=""',
           'provider' => 'windows'
         )
       end
@@ -50,7 +64,14 @@ describe 'windows_firewall::exception', type: :define do
   ['Windows Server 2003', 'Windows Server 2003 R2', 'Windows XP'].each do |os|
     context "program rule with OS: #{os}, ensure: present" do
       let :facts do
-        { operatingsystemversion: os }
+        {
+          operatingsystemversion: os,
+          os: {
+            windows: {
+              system32: 'C:\\windows\\system32'
+            }
+          }
+        }
       end
       let(:title) { 'Windows Remote Management' }
       let :params do
@@ -63,7 +84,7 @@ describe 'windows_firewall::exception', type: :define do
 
       it do
         is_expected.to contain_exec('set rule Windows Remote Management').with(
-          'command' => 'C:\\Windows\\System32\\netsh.exe firewall add allowedprogram name="Windows Remote Management" mode=ENABLE program="C:\\foo.exe"',
+          'command' => 'C:\\windows\\system32\\netsh.exe firewall add allowedprogram name="Windows Remote Management" mode=ENABLE program="C:\\foo.exe"',
           'provider' => 'windows'
         )
       end
@@ -73,7 +94,14 @@ describe 'windows_firewall::exception', type: :define do
   ['Windows Server 2012', 'Windows Server 2008', 'Windows Server 2008 R2', 'Windows 8', 'Windows 7', 'Windows Vista'].each do |os|
     context "program rule with OS: #{os}, ensure: present" do
       let :facts do
-        { operatingsystemversion: os }
+        {
+          operatingsystemversion: os,
+          os: {
+            windows: {
+              system32: 'C:\\windows\\system32'
+            }
+          }
+        }
       end
       let(:title) { 'Windows Remote Management' }
       let :params do
@@ -86,7 +114,7 @@ describe 'windows_firewall::exception', type: :define do
 
       it do
         is_expected.to contain_exec('set rule Windows Remote Management').with(
-          'command' => 'C:\\Windows\\System32\\netsh.exe advfirewall firewall add rule name="Windows Remote Management" description="Inbound rule for WinRM" dir=in action=allow enable=yes edge=no program="C:\\foo.exe" remoteip=""',
+          'command' => 'C:\\windows\\system32\\netsh.exe advfirewall firewall add rule name="Windows Remote Management" description="Inbound rule for WinRM" dir=in action=allow enable=yes edge=no program="C:\\foo.exe" remoteip=""',
           'provider' => 'windows'
         )
       end
@@ -96,7 +124,14 @@ describe 'windows_firewall::exception', type: :define do
   ['Windows Server 2003', 'Windows Server 2003 R2', 'Windows XP'].each do |os|
     context "port rule with OS: #{os}, ensure: absent" do
       let :facts do
-        { operatingsystemversion: os }
+        {
+          operatingsystemversion: os,
+          os: {
+            windows: {
+              system32: 'C:\\windows\\system32'
+            }
+          }
+        }
       end
       let(:title) { 'Windows Remote Management' }
       let :params do
@@ -109,7 +144,7 @@ describe 'windows_firewall::exception', type: :define do
 
       it do
         is_expected.to contain_exec('set rule Windows Remote Management').with(
-          'command' => 'C:\\Windows\\System32\\netsh.exe firewall delete portopening name="Windows Remote Management" mode=ENABLE protocol=TCP port=5985',
+          'command' => 'C:\\windows\\system32\\netsh.exe firewall delete portopening name="Windows Remote Management" mode=ENABLE protocol=TCP port=5985',
           'provider' => 'windows'
         )
       end
@@ -119,7 +154,14 @@ describe 'windows_firewall::exception', type: :define do
   ['Windows Server 2012', 'Windows Server 2008', 'Windows Server 2008 R2', 'Windows 8', 'Windows 7', 'Windows Vista'].each do |os|
     context "port rule with OS: #{os}, ensure: absent" do
       let :facts do
-        { operatingsystemversion: os }
+        {
+          operatingsystemversion: os,
+          os: {
+            windows: {
+              system32: 'C:\\windows\\system32'
+            }
+          }
+        }
       end
       let(:title) { 'Windows Remote Management' }
       let :params do
@@ -132,7 +174,7 @@ describe 'windows_firewall::exception', type: :define do
 
       it do
         is_expected.to contain_exec('set rule Windows Remote Management').with(
-          'command' => 'C:\\Windows\\System32\\netsh.exe advfirewall firewall delete rule name="Windows Remote Management"  dir=in protocol=TCP localport=5985 remoteport=any remoteip=""',
+          'command' => 'C:\\windows\\system32\\netsh.exe advfirewall firewall delete rule name="Windows Remote Management"  dir=in protocol=TCP localport=5985 remoteport=any remoteip=""',
           'provider' => 'windows'
         )
       end
@@ -142,7 +184,14 @@ describe 'windows_firewall::exception', type: :define do
   ['Windows Server 2003', 'Windows Server 2003 R2', 'Windows XP'].each do |os|
     context "program rule with OS: #{os}, ensure: absent" do
       let :facts do
-        { operatingsystemversion: os }
+        {
+          operatingsystemversion: os,
+          os: {
+            windows: {
+              system32: 'C:\\windows\\system32'
+            }
+          }
+        }
       end
       let(:title) { 'Windows Remote Management' }
       let :params do
@@ -155,7 +204,7 @@ describe 'windows_firewall::exception', type: :define do
 
       it do
         is_expected.to contain_exec('set rule Windows Remote Management').with(
-          'command' => 'C:\\Windows\\System32\\netsh.exe firewall delete allowedprogram name="Windows Remote Management" mode=ENABLE program="C:\\foo.exe"',
+          'command' => 'C:\\windows\\system32\\netsh.exe firewall delete allowedprogram name="Windows Remote Management" mode=ENABLE program="C:\\foo.exe"',
           'provider' => 'windows'
         )
       end
@@ -165,7 +214,14 @@ describe 'windows_firewall::exception', type: :define do
   ['Windows Server 2012', 'Windows Server 2008', 'Windows Server 2008 R2', 'Windows 8', 'Windows 7', 'Windows Vista'].each do |os|
     context "program rule with OS: #{os}, ensure: absent" do
       let :facts do
-        { operatingsystemversion: os }
+        {
+          operatingsystemversion: os,
+          os: {
+            windows: {
+              system32: 'C:\\windows\\system32'
+            }
+          }
+        }
       end
       let(:title) { 'Windows Remote Management' }
       let :params do
@@ -178,7 +234,7 @@ describe 'windows_firewall::exception', type: :define do
 
       it do
         is_expected.to contain_exec('set rule Windows Remote Management').with(
-          'command' => 'C:\\Windows\\System32\\netsh.exe advfirewall firewall delete rule name="Windows Remote Management"  dir=in action=allow enable=yes edge=no program="C:\\foo.exe" remoteip=""',
+          'command' => 'C:\\windows\\system32\\netsh.exe advfirewall firewall delete rule name="Windows Remote Management"  dir=in action=allow enable=yes edge=no program="C:\\foo.exe" remoteip=""',
           'provider' => 'windows'
         )
       end
@@ -188,7 +244,14 @@ describe 'windows_firewall::exception', type: :define do
   ['Windows Server 2012', 'Windows Server 2008', 'Windows Server 2008 R2', 'Windows Server 2003 R2', 'Windows Server 2003', 'Windows 8', 'Windows 7', 'Windows Vista', 'Windows XP'].each do |os|
     context "with invalid custom param: os => #{os}, ensure => fubar" do
       let :facts do
-        { operatingsystemversion: os }
+        {
+          operatingsystemversion: os,
+          os: {
+            windows: {
+              system32: 'C:\\windows\\system32'
+            }
+          }
+        }
       end
       let(:title) { 'Windows Remote Management' }
       let :params do
@@ -215,7 +278,14 @@ describe 'windows_firewall::exception', type: :define do
         kQmssLmRxKxxtQ1YKithCfinHOQeDpDXxAtcRsHyKCjjDTt8bZREKexMxx2t'
 
       let :facts do
-        { operatingsystemversion: os }
+        {
+          operatingsystemversion: os,
+          os: {
+            windows: {
+              system32: 'C:\\windows\\system32'
+            }
+          }
+        }
       end
       let(:title) { 'Windows Remote Management' }
 
@@ -238,7 +308,14 @@ describe 'windows_firewall::exception', type: :define do
   ['Windows Server 2012', 'Windows Server 2008', 'Windows Server 2008 R2', 'Windows Server 2003 R2', 'Windows Server 2003', 'Windows 8', 'Windows 7', 'Windows Vista', 'Windows XP'].each do |os|
     context "with invalid custom param: os => #{os}, enabled => fubar" do
       let :facts do
-        { operatingsystemversion: os }
+        {
+          operatingsystemversion: os,
+          os: {
+            windows: {
+              system32: 'C:\\windows\\system32'
+            }
+          }
+        }
       end
       let(:title) { 'Windows Remote Management' }
       let :params do
@@ -260,7 +337,14 @@ describe 'windows_firewall::exception', type: :define do
   ['Windows Server 2012', 'Windows Server 2008', 'Windows Server 2008 R2', 'Windows Server 2003 R2', 'Windows Server 2003', 'Windows 8', 'Windows 7', 'Windows Vista', 'Windows XP'].each do |os|
     context "with invalid custom param: os => #{os}, protocol => fubar" do
       let :facts do
-        { operatingsystemversion: os }
+        {
+          operatingsystemversion: os,
+          os: {
+            windows: {
+              system32: 'C:\\windows\\system32'
+            }
+          }
+        }
       end
       let(:title) { 'Windows Remote Management' }
       let :params do
@@ -282,7 +366,14 @@ describe 'windows_firewall::exception', type: :define do
   ['Windows Server 2012', 'Windows Server 2008', 'Windows Server 2008 R2', 'Windows Server 2003 R2', 'Windows Server 2003', 'Windows 8', 'Windows 7', 'Windows Vista', 'Windows XP'].each do |os|
     context "with invalid custom param: os => #{os}, local_port => fubar" do
       let :facts do
-        { operatingsystemversion: os }
+        {
+          operatingsystemversion: os,
+          os: {
+            windows: {
+              system32: 'C:\\windows\\system32'
+            }
+          }
+        }
       end
       let(:title) { 'Windows Remote Management' }
       let :params do
@@ -309,7 +400,14 @@ describe 'windows_firewall::exception', type: :define do
         kQmssLmRxKxxtQ1YKithCfinHOQeDpDXxAtcRsHyKCjjDTt8bZREKexMxx2t'
 
       let :facts do
-        { operatingsystemversion: 'Windows Server 2008 R2' }
+        {
+          operatingsystemversion: 'Windows Server 2008 R2',
+          os: {
+            windows: {
+              system32: 'C:\\windows\\system32'
+            }
+          }
+        }
       end
       let(:title) { 'Windows Remote Management' }
 
@@ -337,7 +435,14 @@ describe 'windows_firewall::exception', type: :define do
         kQmssLmRxKxxtQ1YKithCfinHOQeDpDXxAtcRsHyKCjjDTt8bZREKexMxx2t'
 
       let :facts do
-        { operatingsystemversion: os }
+        {
+          operatingsystemversion: os,
+          os: {
+            windows: {
+              system32: 'C:\\windows\\system32'
+            }
+          }
+        }
       end
       let(:title) { 'Windows Remote Management' }
 
@@ -360,7 +465,14 @@ describe 'windows_firewall::exception', type: :define do
   ['Windows Server 2012', 'Windows Server 2008', 'Windows Server 2008 R2', 'Windows 8', 'Windows 7', 'Windows Vista'].each do |os|
     context "with invalid custom param: os => #{os}, direction => fubar" do
       let :facts do
-        { operatingsystemversion: os }
+        {
+          operatingsystemversion: os,
+          os: {
+            windows: {
+              system32: 'C:\\windows\\system32'
+            }
+          }
+        }
       end
       let(:title) { 'Windows Remote Management' }
       let :params do
@@ -382,7 +494,14 @@ describe 'windows_firewall::exception', type: :define do
   ['Windows Server 2003', 'Windows Server 2003 R2', 'Windows XP'].each do |os|
     context "with invalid custom param: os => #{os}, direction => fubar" do
       let :facts do
-        { operatingsystemversion: os }
+        {
+          operatingsystemversion: os,
+          os: {
+            windows: {
+              system32: 'C:\\windows\\system32'
+            }
+          }
+        }
       end
       let(:title) { 'Windows Remote Management' }
       let :params do
@@ -404,7 +523,14 @@ describe 'windows_firewall::exception', type: :define do
   ['Windows Server 2012', 'Windows Server 2008', 'Windows Server 2008 R2', 'Windows 8', 'Windows 7', 'Windows Vista'].each do |os|
     context "with invalid custom param: os => #{os}, action => fubar" do
       let :facts do
-        { operatingsystemversion: os }
+        {
+          operatingsystemversion: os,
+          os: {
+            windows: {
+              system32: 'C:\\windows\\system32'
+            }
+          }
+        }
       end
       let(:title) { 'Windows Remote Management' }
       let :params do
@@ -426,7 +552,14 @@ describe 'windows_firewall::exception', type: :define do
   ['Windows Server 2003', 'Windows Server 2003 R2', 'Windows XP'].each do |os|
     context "with invalid custom param: os => #{os}, action => fubar" do
       let :facts do
-        { operatingsystemversion: os }
+        {
+          operatingsystemversion: os,
+          os: {
+            windows: {
+              system32: 'C:\\windows\\system32'
+            }
+          }
+        }
       end
       let(:title) { 'Windows Remote Management' }
       let :params do


### PR DESCRIPTION
This uses the os structured fact to grab the location of the system32 folder on a windows machine and builds the netsh.exe path from it.  This Fixes #52