### PR TITLE
Port range

### DIFF
--- a/manifests/exception.pp
+++ b/manifests/exception.pp
@@ -209,19 +209,22 @@ define windows_firewall::exception(
         true  => 'yes',
         false => 'no',
       }
-      if($program_cmd){
-        $allow_context = rstrip("action=${action} enable=${mode} edge=${edge} ${program_cmd} ${protocol_cmd} ${local_port_cmd} ${remote_port_cmd}")
+
+      if($remote_ip){
+        $remote_ip_cmd = "remoteip=\"${remote_ip}\""
+      }else{
+        $remote_ip_cmd = undef
       }
-      else{
-        $allow_context = rstrip("action=${action} enable=${mode} edge=${edge} ${protocol_cmd} ${local_port_cmd} ${remote_port_cmd}")
-      }
+
+      $allow_context = regsubst("action=${action} enable=${mode} edge=${edge} ${program_cmd} ${protocol_cmd} ${local_port_cmd} ${remote_port_cmd} ${remote_ip_cmd} profile=\"Any\"",'[\s]{2,}',' ','G')
+
 
       if $ensure != 'present' {
         $fw_description = ''
         $netsh_command = "${netsh_exe} advfirewall firewall delete rule name=\"${display_name}\""
       } else {
         $fw_description = "description=\"${description}\""
-        $netsh_command = "${netsh_exe} advfirewall firewall add rule name=\"${display_name}\" description=\"${description}\" dir=${direction} ${allow_context} remoteip=\"${remote_ip}\" profile=\"Any\""
+        $netsh_command = "${netsh_exe} advfirewall firewall add rule name=\"${display_name}\" description=\"${description}\" dir=${direction} ${allow_context}"
       }
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,7 +8,7 @@
 #
 # === Requirements/Dependencies
 #
-# Currently reequires the puppetlabs/stdlib module on the Puppet Forge in
+# Currently requires the puppetlabs/stdlib module on the Puppet Forge in
 # order to validate much of the the provided configuration.
 #
 # === Parameters
@@ -18,7 +18,7 @@
 #
 # === Examples
 #
-# To ensure that windows_firwall is running:
+# To ensure that windows_firewall is running:
 #
 #   include ::windows_firewall
 #

--- a/spec/defines/windows_firewall/exception_spec.rb
+++ b/spec/defines/windows_firewall/exception_spec.rb
@@ -24,7 +24,7 @@ describe 'windows_firewall::exception', type: :define do
 
       it do
         is_expected.to contain_exec('set rule Windows Remote Management').with(
-          'command' => 'C:\\windows\\system32\\netsh.exe firewall add portopening name="Windows Remote Management" mode=ENABLE protocol=TCP port=5985',
+          'command' => 'C:\\windows\\system32\\netsh.exe firewall add portopening name="Windows Remote Management" mode=ENABLE protocol=TCP port="5985"',
           'provider' => 'windows'
         )
       end
@@ -54,7 +54,7 @@ describe 'windows_firewall::exception', type: :define do
 
       it do
         is_expected.to contain_exec('set rule Windows Remote Management').with(
-          'command' => 'C:\\windows\\system32\\netsh.exe advfirewall firewall add rule name="Windows Remote Management" description="Inbound rule for WinRM" dir=in action=allow enable=yes edge=no protocol=TCP localport=5985 remoteport=any remoteip=""',
+          'command' => 'C:\\windows\\system32\\netsh.exe advfirewall firewall add rule name="Windows Remote Management" description="Inbound rule for WinRM" dir=in action=allow enable=yes edge=no protocol=TCP localport="5985" remoteport="any" remoteip="" profile="Any"',
           'provider' => 'windows'
         )
       end
@@ -114,7 +114,7 @@ describe 'windows_firewall::exception', type: :define do
 
       it do
         is_expected.to contain_exec('set rule Windows Remote Management').with(
-          'command' => 'C:\\windows\\system32\\netsh.exe advfirewall firewall add rule name="Windows Remote Management" description="Inbound rule for WinRM" dir=in action=allow enable=yes edge=no program="C:\\foo.exe" remoteip=""',
+          'command' => 'C:\\windows\\system32\\netsh.exe advfirewall firewall add rule name="Windows Remote Management" description="Inbound rule for WinRM" dir=in action=allow enable=yes edge=no program="C:\\foo.exe" remoteip="" profile="Any"',
           'provider' => 'windows'
         )
       end
@@ -144,7 +144,7 @@ describe 'windows_firewall::exception', type: :define do
 
       it do
         is_expected.to contain_exec('set rule Windows Remote Management').with(
-          'command' => 'C:\\windows\\system32\\netsh.exe firewall delete portopening name="Windows Remote Management" mode=ENABLE protocol=TCP port=5985',
+          'command' => 'C:\\windows\\system32\\netsh.exe firewall delete portopening name="Windows Remote Management" mode=ENABLE protocol=TCP port="5985"',
           'provider' => 'windows'
         )
       end
@@ -174,7 +174,7 @@ describe 'windows_firewall::exception', type: :define do
 
       it do
         is_expected.to contain_exec('set rule Windows Remote Management').with(
-          'command' => 'C:\\windows\\system32\\netsh.exe advfirewall firewall delete rule name="Windows Remote Management"  dir=in protocol=TCP localport=5985 remoteport=any remoteip=""',
+          'command' => 'C:\\windows\\system32\\netsh.exe advfirewall firewall delete rule name="Windows Remote Management"',
           'provider' => 'windows'
         )
       end
@@ -234,7 +234,7 @@ describe 'windows_firewall::exception', type: :define do
 
       it do
         is_expected.to contain_exec('set rule Windows Remote Management').with(
-          'command' => 'C:\\windows\\system32\\netsh.exe advfirewall firewall delete rule name="Windows Remote Management"  dir=in action=allow enable=yes edge=no program="C:\\foo.exe" remoteip=""',
+          'command' => 'C:\\windows\\system32\\netsh.exe advfirewall firewall delete rule name="Windows Remote Management"',
           'provider' => 'windows'
         )
       end
@@ -574,6 +574,120 @@ describe 'windows_firewall::exception', type: :define do
         expect do
           is_expected.to contain_exec('set rule Windows Remote Management')
         end.to raise_error(Puppet::Error, %r{expects a match for Enum})
+      end
+    end
+  end
+  ['Windows Server 2012', 'Windows Server 2008', 'Windows Server 2008 R2', 'Windows 8', 'Windows 7', 'Windows Vista'].each do |os|
+    context "port rule with OS: #{os}, ensure: present" do
+      let :facts do
+        {
+          operatingsystemversion: os,
+          os: {
+            windows: {
+              system32: 'C:\\windows\\system32'
+            }
+          }
+        }
+      end
+      let(:title) { 'Windows Remote Management' }
+      let :params do
+        {
+          ensure: 'present', direction: 'in', action: 'allow', enabled: true,
+          protocol: 'TCP', local_port: '1000-2000,2048', remote_port: 'any',
+          display_name: 'Windows Remote Management', description: 'Inbound rule for WinRM'
+        }
+      end
+
+      it do
+        is_expected.to contain_exec('set rule Windows Remote Management').with(
+          'command' => 'C:\\windows\\system32\\netsh.exe advfirewall firewall add rule name="Windows Remote Management" description="Inbound rule for WinRM" dir=in action=allow enable=yes edge=no protocol=TCP localport="1000-2000,2048" remoteport="any" remoteip="" profile="Any"',
+          'provider' => 'windows'
+        )
+      end
+    end
+  end
+  ['Windows Server 2012', 'Windows Server 2008', 'Windows Server 2008 R2', 'Windows 8', 'Windows 7', 'Windows Vista'].each do |os|
+    context "port rule with OS: #{os}, ensure: present" do
+      let :facts do
+        {
+          operatingsystemversion: os,
+          os: {
+            windows: {
+              system32: 'C:\\windows\\system32'
+            }
+          }
+        }
+      end
+      let(:title) { 'Windows Remote Management' }
+      let :params do
+        {
+          ensure: 'present', direction: 'in', action: 'allow', enabled: true,
+          protocol: 'TCP', local_port: 'RPC', remote_port: 'any',
+          display_name: 'Windows Remote Management', description: 'Inbound rule for WinRM'
+        }
+      end
+
+      it do
+        is_expected.to contain_exec('set rule Windows Remote Management').with(
+          'command' => 'C:\\windows\\system32\\netsh.exe advfirewall firewall add rule name="Windows Remote Management" description="Inbound rule for WinRM" dir=in action=allow enable=yes edge=no protocol=TCP localport="RPC" remoteport="any" remoteip="" profile="Any"',
+          'provider' => 'windows'
+        )
+      end
+    end
+  end
+  ['Windows Server 2012', 'Windows Server 2008', 'Windows Server 2008 R2', 'Windows 8', 'Windows 7', 'Windows Vista'].each do |os|
+    context "with invalid custom param: os => #{os}, action => invalid" do
+      let :facts do
+        {
+          operatingsystemversion: os,
+          os: {
+            windows: {
+              system32: 'C:\\windows\\system32'
+            }
+          }
+        }
+      end
+      let(:title) { 'Windows Remote Management' }
+      let :params do
+        {
+          ensure: 'present', direction: 'in', action: 'allow', enabled: true,
+          protocol: 'UDP', local_port: 'RPC',
+          display_name: 'Windows Remote Management', description: 'Inbound rule for WinRM'
+        }
+      end
+
+      it do
+        expect do
+          is_expected.to contain_exec('set rule Windows Remote Management')
+        end.to raise_error(Puppet::Error, %r{RPC and RPC-EPMap local ports require TCP})
+      end
+    end
+  end
+  ['Windows Server 2012', 'Windows Server 2008', 'Windows Server 2008 R2', 'Windows 8', 'Windows 7', 'Windows Vista'].each do |os|
+    context "with invalid custom param: os => #{os}, action => invalid" do
+      let :facts do
+        {
+          operatingsystemversion: os,
+          os: {
+            windows: {
+              system32: 'C:\\windows\\system32'
+            }
+          }
+        }
+      end
+      let(:title) { 'Windows Remote Management' }
+      let :params do
+        {
+          ensure: 'present', direction: 'in', action: 'allow', enabled: true,
+          protocol: 'ICMPv4', local_port: 'RPC',
+          display_name: 'Windows Remote Management', description: 'Inbound rule for WinRM'
+        }
+      end
+
+      it do
+        expect do
+          is_expected.to contain_exec('set rule Windows Remote Management')
+        end.to raise_error(Puppet::Error, %r{local and/or remote ports are not needed when protocol is ICMP})
       end
     end
   end

--- a/spec/defines/windows_firewall/exception_spec.rb
+++ b/spec/defines/windows_firewall/exception_spec.rb
@@ -54,7 +54,7 @@ describe 'windows_firewall::exception', type: :define do
 
       it do
         is_expected.to contain_exec('set rule Windows Remote Management').with(
-          'command' => 'C:\\windows\\system32\\netsh.exe advfirewall firewall add rule name="Windows Remote Management" description="Inbound rule for WinRM" dir=in action=allow enable=yes edge=no protocol=TCP localport="5985" remoteport="any" remoteip="" profile="Any"',
+          'command' => 'C:\\windows\\system32\\netsh.exe advfirewall firewall add rule name="Windows Remote Management" description="Inbound rule for WinRM" dir=in action=allow enable=yes edge=no protocol=TCP localport="5985" remoteport="any" profile="Any"',
           'provider' => 'windows'
         )
       end
@@ -114,7 +114,7 @@ describe 'windows_firewall::exception', type: :define do
 
       it do
         is_expected.to contain_exec('set rule Windows Remote Management').with(
-          'command' => 'C:\\windows\\system32\\netsh.exe advfirewall firewall add rule name="Windows Remote Management" description="Inbound rule for WinRM" dir=in action=allow enable=yes edge=no program="C:\\foo.exe" remoteip="" profile="Any"',
+          'command' => 'C:\\windows\\system32\\netsh.exe advfirewall firewall add rule name="Windows Remote Management" description="Inbound rule for WinRM" dir=in action=allow enable=yes edge=no program="C:\\foo.exe" profile="Any"',
           'provider' => 'windows'
         )
       end
@@ -600,7 +600,7 @@ describe 'windows_firewall::exception', type: :define do
 
       it do
         is_expected.to contain_exec('set rule Windows Remote Management').with(
-          'command' => 'C:\\windows\\system32\\netsh.exe advfirewall firewall add rule name="Windows Remote Management" description="Inbound rule for WinRM" dir=in action=allow enable=yes edge=no protocol=TCP localport="1000-2000,2048" remoteport="any" remoteip="" profile="Any"',
+          'command' => 'C:\\windows\\system32\\netsh.exe advfirewall firewall add rule name="Windows Remote Management" description="Inbound rule for WinRM" dir=in action=allow enable=yes edge=no protocol=TCP localport="1000-2000,2048" remoteport="any" profile="Any"',
           'provider' => 'windows'
         )
       end
@@ -629,7 +629,7 @@ describe 'windows_firewall::exception', type: :define do
 
       it do
         is_expected.to contain_exec('set rule Windows Remote Management').with(
-          'command' => 'C:\\windows\\system32\\netsh.exe advfirewall firewall add rule name="Windows Remote Management" description="Inbound rule for WinRM" dir=in action=allow enable=yes edge=no protocol=TCP localport="RPC" remoteport="any" remoteip="" profile="Any"',
+          'command' => 'C:\\windows\\system32\\netsh.exe advfirewall firewall add rule name="Windows Remote Management" description="Inbound rule for WinRM" dir=in action=allow enable=yes edge=no protocol=TCP localport="RPC" remoteport="any" profile="Any"',
           'provider' => 'windows'
         )
       end
@@ -688,6 +688,36 @@ describe 'windows_firewall::exception', type: :define do
         expect do
           is_expected.to contain_exec('set rule Windows Remote Management')
         end.to raise_error(Puppet::Error, %r{local and/or remote ports are not needed when protocol is ICMP})
+      end
+    end
+  end
+  ['Windows Server 2012', 'Windows Server 2008', 'Windows Server 2008 R2', 'Windows 8', 'Windows 7', 'Windows Vista'].each do |os|
+    context "port rule with OS: #{os}, ensure: present" do
+      let :facts do
+        {
+          operatingsystemversion: os,
+          os: {
+            windows: {
+              system32: 'C:\\windows\\system32'
+            }
+          }
+        }
+      end
+      let(:title) { 'Windows Remote Management' }
+      let :params do
+        {
+          ensure: 'present', direction: 'in', action: 'allow', enabled: true,
+          protocol: 'TCP', local_port: 'RPC', remote_port: 'any',
+          display_name: 'Windows Remote Management', description: 'Inbound rule for WinRM',
+          remote_ip: '10.10.10.10'
+        }
+      end
+
+      it do
+        is_expected.to contain_exec('set rule Windows Remote Management').with(
+          'command' => 'C:\\windows\\system32\\netsh.exe advfirewall firewall add rule name="Windows Remote Management" description="Inbound rule for WinRM" dir=in action=allow enable=yes edge=no protocol=TCP localport="RPC" remoteport="any" remoteip="10.10.10.10" profile="Any"',
+          'provider' => 'windows'
+        )
       end
     end
   end


### PR DESCRIPTION

#### Pull Request (PR) description
This PR 

1. Fixes some typos
2. Adds support for comma-separated port list and dash separated range for Local and Remote ports
3. Adds support for 'RPC' and 'RPC-EPMap' port ranges for local ports
4. Adds default description 
5. Makes sure ICMPv4/v6 protocol does not accept ports
6. Makes sure 'RPC' and 'RPC-EPMap' only use TCP
7. Adds Win2k3/XP specific check for rule existence


#### This Pull Request (PR) fixes the following issues
#80 
