### PR TITLE
Bump puppetlabs/registry

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -25,7 +25,7 @@
     },
     {
       "name": "puppetlabs/registry",
-      "version_requirement": ">= 1.1.1 < 3.0.0"
+      "version_requirement": ">= 1.1.1 < 4.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
Appears to work properly with current puppetlabs/registry 3.0.0, so bump for availability

#### Pull Request (PR) description
Bump puppetlabs/registry pre-req to support current (3.0.0).

#### This Pull Request (PR) fixes the following issues
Fixes #29