### PR TITLE
Fixed provider for making changes via Puppet

### DIFF
--- a/lib/puppet/provider/windowsfirewall/powershell.rb
+++ b/lib/puppet/provider/windowsfirewall/powershell.rb
@@ -76,7 +76,8 @@ Puppet::Type.type(:windowsfirewall).provide(:powershell) do
 
     def self.prefetch(resources)
       instances.each do |prov|
-        resource.provider = prov if resource == resources[prov.name]
+        res = resources[prov.name]
+        res.provider = prov if res
       end
     end
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

While the resource was correctly displaying the types via puppet resource, it was experiencing errors enforcing the provider code with Puppet.


#### This Pull Request (PR) fixes the following issues

No issues listed yet


### Error message

```Error: Could not prefetch windowsfirewall provider 'powershell': undefined local variable or method `resource' for Puppet::Type::Windowsfirewall::ProviderPowershell:Class
Did you mean?  resources
Error: Failed to apply catalog: undefined local variable or method `resource' for Puppet::Type::Windowsfirewall::ProviderPowershell:Class
Did you mean?  resources```
