### PR TITLE
Fix truncated verification

### DIFF
--- a/lib/puppet/provider/windowsfirewall/powershell.rb
+++ b/lib/puppet/provider/windowsfirewall/powershell.rb
@@ -82,7 +82,7 @@ Puppet::Type.type(:windowsfirewall).provide(:powershell) do
     end
 
     def self.get_firewall_properties(zone)
-      output = powershell(['Get-NetFirewallProfile', '-profile', "\"#{zone}\""]).split("\n")
+      output = powershell(['Get-NetFirewallProfile', '-profile', "\"#{zone}\"", '|', 'out-string', '-width', '4096']).split("\n")
       3.times { output.shift }
       hash_of_properties = {}
       output.each do |line|


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
I ran in to an issue where '%SystemRoot%\System32\logfiles\firewall\publicfw.log' was not being validated properly. The powershell output of Get-NetFirewallProfile was getting wrapped so only '%SystemRoot%\System32\logfiles\firewall\publi' was on the first line. This resulted in the log file being changed every time Puppet ran. This change sets the output length to 4096, which should be more than enough for long file names. After changing it locally, I was able to run Puppet with the current setting properly being validated and again with it being told to make a change.

#### This Pull Request (PR) fixes the following issues
None that I can find.
