### PR TITLE
Fixing display_name to default to the resource title

### DIFF
--- a/manifests/exception.pp
+++ b/manifests/exception.pp
@@ -38,7 +38,7 @@
 # Specifies that network packets with matching remote IP port numbers matched by this rule.
 #
 # [*display_name*]
-# Specifies the rule name assigned to the rule that you want to display
+# Specifies the rule name assigned to the rule that you want to display. Defaults to the title of the resource.
 #
 # [*description*]
 # Provides information about the firewall rule.
@@ -86,7 +86,7 @@ define windows_firewall::exception (
   Windows_firewall::Port  $remote_port = undef,
   Optional[String] $remote_ip = undef,
   Optional[Stdlib::Windowspath] $program = undef,
-  String[0, 255] $display_name = '',
+  String[0, 255] $display_name = $title,
   String[0, 255] $description = '',
   Boolean $allow_edge_traversal = false,
 ) {

--- a/spec/defines/windows_firewall/exception_spec.rb
+++ b/spec/defines/windows_firewall/exception_spec.rb
@@ -401,4 +401,34 @@ describe 'windows_firewall::exception', type: :define do
       end
     end
   end
+
+  ['Windows Server 2012', 'Windows Server 2008', 'Windows Server 2008 R2', 'Windows 8', 'Windows 7'].each do |os|
+    context "resource title rule with OS: #{os}, ensure: present" do
+      let :facts do
+        {
+          os: {
+            windows: {
+              system32: 'C:\\windows\\system32'
+            }
+          }
+        }
+      end
+      let(:title) { 'Windows Remote Management' }
+      let :params do
+        {
+          ensure: 'present', direction: 'in', action: 'allow', enabled: true,
+          protocol: 'TCP', local_port: 5985, remote_port: 'any',
+          description: 'Inbound rule for WinRM'
+        }
+      end
+
+      it do
+        is_expected.to contain_exec('set rule Windows Remote Management').with(
+          'command' => 'C:\\windows\\system32\\netsh.exe advfirewall firewall add rule name="Windows Remote Management" description="Inbound rule for WinRM" dir=in action=allow enable=yes edge=no protocol=TCP localport=5985 remoteport=any remoteip=""',
+          'provider' => 'windows'
+        )
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
#### Pull Request (PR) description
According to the README.md the display_name parameter of the exception resource should default to the resource title.  Prior to this PR, display_name is set to an empty string which causes issues if you define multiple exceptions without setting the display_name.  This PR corrects this issue by setting the default to the resource title.

#### This Pull Request (PR) fixes the following issues
n/a
